### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"phpunit/phpunit" : "4.4.*",
 		"sebastian/phpcpd" : "2.0.*",
 		"squizlabs/php_codesniffer" : "2.2.*",
-		"phpdocumentor/phpdocumentor" : "2.8.*"
+		"phpdocumentor/phpdocumentor" : "2.9.*"
 	},
 	"authors" : [{
 			"name" : "Tim Wagner",


### PR DESCRIPTION
This resolves incompatibilities with applications which need current versions of jms/serializer (phpdocumentator/phpdocumentator 2.8 and lower require older versions of jms/serializer)